### PR TITLE
feat: basic highlighting for ssr markup

### DIFF
--- a/packages/@lwc/wds-playground/src/browser/ui/pg/codejar/codejar.css
+++ b/packages/@lwc/wds-playground/src/browser/ui/pg/codejar/codejar.css
@@ -15,3 +15,19 @@
 :host(.no-margin) .editor {
   margin: 0;
 }
+
+.highlight-tag {
+  color: blue;
+}
+
+.highlight-attr {
+  color: red;
+}
+
+.highlight-equals {
+  color: black;
+}
+
+.highlight-value {
+  color: green;
+}

--- a/packages/@lwc/wds-playground/src/browser/ui/pg/codejar/codejar.js
+++ b/packages/@lwc/wds-playground/src/browser/ui/pg/codejar/codejar.js
@@ -56,6 +56,10 @@ function highlightHtmlText(text) {
   return highlightHtmlAst(ast.children);
 }
 
+/**
+ * @param {any[]} ast
+ * @returns {string}
+ */
 function highlightHtmlAst(ast) {
   let result = '';
   for (const node of ast) {
@@ -70,9 +74,13 @@ function highlightHtmlAst(ast) {
           result += `<span class="highlight-value">"${attr.value}"</span>`;
         }
       }
-      result += '<span class="highlight-tag">&gt;</span>';
-      result += highlightHtmlAst(node.children);
-      result += `<span class="highlight-tag">&lt;/${node.name}&gt;</span>`;
+      if (node.tagDefinition.isVoid) {
+        result += '<span class="highlight-tag"> /&gt;</span>';
+      } else {
+        result += '<span class="highlight-tag">&gt;</span>';
+        result += highlightHtmlAst(node.children);
+        result += `<span class="highlight-tag">&lt;/${node.name}&gt;</span>`;
+      }
     }
   }
   return result;

--- a/packages/@lwc/wds-playground/src/browser/ui/pg/codejar/codejar.js
+++ b/packages/@lwc/wds-playground/src/browser/ui/pg/codejar/codejar.js
@@ -1,5 +1,6 @@
 import { CodeJar } from 'codejar';
 import { LightningElement, api } from 'lwc';
+import htmlPlugin from 'prettier/esm/parser-html.mjs';
 
 export default class Codejar extends LightningElement {
   @api nomargin = false;
@@ -28,7 +29,13 @@ export default class Codejar extends LightningElement {
     }
     this.hasRendered = true;
     const editorEl = this.template.querySelector('.editor');
-    this.jar = new CodeJar(editorEl, () => {}, { tab: '  ' });
+    this.jar = new CodeJar(
+      editorEl,
+      (editor) => {
+        editor.innerHTML = highlightHtmlText(editor.textContent);
+      },
+      { tab: '  ' },
+    );
     this.jar.updateCode(this.content);
     editorEl.addEventListener('input', () => (this._content = this.jar.toString()));
   }
@@ -38,4 +45,35 @@ export default class Codejar extends LightningElement {
       evt.stopPropagation();
     }
   }
+}
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function highlightHtmlText(text) {
+  const ast = htmlPlugin.parsers.html.parse(text);
+  return highlightHtmlAst(ast.children);
+}
+
+function highlightHtmlAst(ast) {
+  let result = '';
+  for (const node of ast) {
+    if (node.type === 'text') {
+      result += node.value;
+    } else {
+      result += `<span class="highlight-tag">&lt;${node.name}</span>`;
+      for (const attr of node.attrs) {
+        result += `<span class="highlight-attr"> ${attr.name}</span>`;
+        if (attr.value) {
+          result += '<span class="highlight-equals">=</span>';
+          result += `<span class="highlight-value">"${attr.value}"</span>`;
+        }
+      }
+      result += '<span class="highlight-tag">&gt;</span>';
+      result += highlightHtmlAst(node.children);
+      result += `<span class="highlight-tag">&lt;/${node.name}&gt;</span>`;
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
Basic syntax highlighting for the SSR markup. 

<img width="904" alt="Screenshot 2024-06-06 at 13 27 55" src="https://github.com/salesforce/lightning-labs/assets/5606812/05a22106-8d78-4718-b72d-f8edbe200f03">

I'm not sure you're taking PRs yet, but this project would replace a lot of ad-hoc tooling I've been maintaining for my day job, so I'd love to contribute.