### PR TITLE
fix: bug in errorInConnectedCallbackAssertion that disallowed inverse usage of the assertion

### DIFF
--- a/packages/@lwc/test-runner/src/browser/lwc-life-cycle.js
+++ b/packages/@lwc/test-runner/src/browser/lwc-life-cycle.js
@@ -24,7 +24,7 @@ async function errorInConnectedCallbackAssertion(utils, self, message) {
   }
 
   const finalError = syncError || asyncError;
-  assert.equal(finalError.message, message, `Expected to throw ${message}`);
+  assert.equal(finalError?.message, message, `Expected to throw ${message}`);
 }
 
 chai.use((_chai, utils) => {


### PR DESCRIPTION
An assertion matcher could be used in this way:

```javascript
 await expect(async () => {
  await renderToMarkup(componentPath, badProps);
}).to.throwErrorInConnectedCallback();
```

However, the following would fail:

```javascript
 await expect(async () => {
  await renderToMarkup(componentPath, goodProps);
}).to.not.throwErrorInConnectedCallback();
```

The fix allows `to.not.throwErrorInConnectedCallback` to be used successfully.