### PR TITLE
fix: non-existing implicit HTML and CSS imports

### DIFF
--- a/example/src/modules/x/badChild/badChild.html
+++ b/example/src/modules/x/badChild/badChild.html
@@ -1,0 +1,3 @@
+<template>
+  <p class='child-content'>Message: {badmessage}</p>
+</template>

--- a/example/src/modules/x/badChild/badChild.js
+++ b/example/src/modules/x/badChild/badChild.js
@@ -1,0 +1,10 @@
+import { LightningElement, api } from 'lwc';
+
+export default class App extends LightningElement {
+  @api message = '';
+  get badmessage() {
+    // Intentionally rendering differently in SSR & CSR to demonstrate
+    // the playground functionality.
+    return import.meta.env.SSR ? `${this.badmessage} oops SSR oops` : this.message;
+  }
+}

--- a/example/src/modules/x/child/child.css
+++ b/example/src/modules/x/child/child.css
@@ -1,6 +1,0 @@
-.child-content {
-	padding: 8px;
-	margin: 0;
-	background-color: rgba(255, 255, 255, 0.5);
-	color: black;
-}

--- a/example/src/modules/x/child/child.html
+++ b/example/src/modules/x/child/child.html
@@ -1,3 +1,3 @@
 <template>
-  <p class='child-content'>Message: {badmessage}</p>
+  <p class='child-content'>Message: {message}</p>
 </template>

--- a/example/src/modules/x/child/child.js
+++ b/example/src/modules/x/child/child.js
@@ -2,9 +2,4 @@ import { LightningElement, api } from 'lwc';
 
 export default class App extends LightningElement {
   @api message = '';
-  get badmessage() {
-    // Intentionally rendering differently in SSR & CSR to demonstrate
-    // the playground functionality.
-    return import.meta.env.SSR ? `${this.message} oops SSR oops` : this.message;
-  }
 }

--- a/packages/@lwc/wds-core/src/node/plugins/lwc/compile.js
+++ b/packages/@lwc/wds-core/src/node/plugins/lwc/compile.js
@@ -16,7 +16,7 @@ export const VIRTUAL_TEMPLATE_EMPTY = '/virtual/empty.html';
 const VIRTUAL_CONTENT = new Map(
   Object.entries({
     [VIRTUAL_CSS_EMPTY]: {
-      body: '',
+      body: 'export default null;',
       type: 'js',
     },
     [VIRTUAL_TEMPLATE_EMPTY]: {
@@ -89,15 +89,19 @@ export default ({ rootDir, moduleDirs }) => ({
   },
 
   resolveImport({ source, context, code, column, line }) {
-    const filePath = getRequestFilePath(context.url, rootDir);
+    const parentModuleFilePath = getRequestFilePath(context.url, rootDir);
+
     const isRelativeImport = source.startsWith('.');
-    const resolvedImport = path.resolve(path.dirname(filePath), source);
+    const resolvedImport = path.resolve(
+      path.dirname(parentModuleFilePath),
+      stripQueryString(source),
+    );
 
     if (isRelativeImport && !fs.existsSync(resolvedImport)) {
-      if (filePath.endsWith('.css')) {
+      if (resolvedImport.endsWith('.css')) {
         return VIRTUAL_CSS_EMPTY;
       }
-      if (filePath.endsWith('.html')) {
+      if (resolvedImport.endsWith('.html')) {
         return VIRTUAL_TEMPLATE_EMPTY;
       }
     }


### PR DESCRIPTION
This wasn't working. It may have never been working. In addition to fixing implicit template and CSS imports, this also fixes the problems with components that use the `render` method to choose which HTML template to use in their component.

Fixes #7