### PR TITLE
feat: makes defineState to receive an object with exposed APIs

### DIFF
--- a/example/src/modules/x/anotherParentState/anotherParentState.js
+++ b/example/src/modules/x/anotherParentState/anotherParentState.js
@@ -1,5 +1,5 @@
 import { defineState } from '@lwc/state';
 
-export default defineState((atom) => (initialName = 'anotherFoo') => ({
+export default defineState(({ atom }) => (initialName = 'anotherFoo') => ({
   name: atom(initialName),
 }));

--- a/example/src/modules/x/childState/childState.js
+++ b/example/src/modules/x/childState/childState.js
@@ -2,7 +2,7 @@ import { defineState } from '@lwc/state';
 import parentStateFactory from 'x/parentState';
 import anotherParentStateFactory from 'x/anotherParentState';
 
-export default defineState((atom, _computed, update, fromContext) => (initialName = 'bar') => {
+export default defineState(({ atom, update, fromContext }) => (initialName = 'bar') => {
   const name = atom(initialName);
   const parentState = fromContext(parentStateFactory);
   const anotherParentState = fromContext(anotherParentStateFactory);

--- a/example/src/modules/x/grandChildState/grandChildState.js
+++ b/example/src/modules/x/grandChildState/grandChildState.js
@@ -1,7 +1,7 @@
 import { defineState } from '@lwc/state';
 import childStateFactory from 'x/childState';
 
-export default defineState((_atom, _computed, _update, fromContext) => () => {
+export default defineState(({ fromContext }) => () => {
   const childState = fromContext(childStateFactory);
 
   return {

--- a/example/src/modules/x/parentState/parentState.js
+++ b/example/src/modules/x/parentState/parentState.js
@@ -1,6 +1,6 @@
 import { defineState } from '@lwc/state';
 
-export default defineState((atom, computed, update, fromContext) => (initialName = 'foo') => {
+export default defineState(({ atom, update }) => (initialName = 'foo') => {
   const name = atom(initialName);
 
   const updateName = update({ name }, (_, newName) => ({

--- a/packages/@lwc/state/README.md
+++ b/packages/@lwc/state/README.md
@@ -24,7 +24,7 @@ yarn add @lwc/state
 
 ### defineState
 
-The main function for creating state definitions. It provides four utilities:
+The main function for creating state definitions. It provides an object with four utilities:
 
 - `atom<T>(initialValue: T)`: Creates a reactive atomic value
 - `computed(signals, computeFn)`: Creates derived state based on provided signals map
@@ -46,7 +46,7 @@ Create a state definition using `defineState`:
 import { defineState } from '@lwc/state';
 
 const useCounter = defineState(
-  (atom, computed, update) =>
+  ({ atom, computed, update }) =>
     (initialValue = 0) => {
       // Create reactive atom
       const count = atom(initialValue);
@@ -106,7 +106,7 @@ const context = defineState(
 import contextFactory from '<parentState>';
 
 const useTheme = defineState(
-  (_atom, _computed, _update, fromContext) =>
+  ({ fromContext }) =>
     () => {
       const theme = fromContext(contextFactory);
         

--- a/packages/@lwc/state/src/__tests__/index.test.ts
+++ b/packages/@lwc/state/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@ let fruitNameAndCountNotifySpy: any;
 // biome-ignore lint: test only
 let fruitNameAndCountComputeValueSpy: any;
 
-const state = defineState((atom, computed, update, _fromContext) => (...args) => {
+const state = defineState(({ atom, computed, update }) => (...args) => {
   const countArg = args[0] as number;
   const fruitArg = args[1] as string;
 

--- a/packages/@lwc/state/src/index.ts
+++ b/packages/@lwc/state/src/index.ts
@@ -4,6 +4,7 @@ import { connectContext, disconnectContext } from './shared.js';
 import type {
   Computer,
   DefineState,
+  ExposedAPIs,
   ExposedUpdater,
   MakeAtom,
   MakeComputed,
@@ -130,12 +131,7 @@ export const defineState: DefineState = <
   Args extends unknown[],
   ContextShape,
 >(
-  defineStateCallback: (
-    atom: MakeAtom,
-    computed: MakeComputed,
-    update: MakeUpdate,
-    fromContext: MakeContextHook<ContextShape>,
-  ) => (...args: Args) => InnerStateShape,
+  defineStateCallback: (api: ExposedAPIs<ContextShape>) => (...args: Args) => InnerStateShape,
 ) => {
   const stateDefinition = (...args: Args) => {
     class StateManagerSignal extends SignalBaseClass<OuterStateShape> implements ContextManager {
@@ -194,7 +190,12 @@ export const defineState: DefineState = <
           return localContextSignal;
         };
 
-        this.internalStateShape = defineStateCallback(atom, computed, update, fromContext)(...args);
+        this.internalStateShape = defineStateCallback({
+          atom,
+          computed,
+          update,
+          fromContext,
+        })(...args);
 
         for (const signalOrUpdater of Object.values(this.internalStateShape)) {
           if (signalOrUpdater && !isUpdater(signalOrUpdater)) {

--- a/packages/@lwc/state/src/types.ts
+++ b/packages/@lwc/state/src/types.ts
@@ -39,6 +39,13 @@ export type ExposedUpdater = (...updaterArgs: unknown[]) => void;
 
 export type ContextSignal<T> = Signal<T> & { id: symbol };
 
+export type ExposedAPIs<ContextShape> = {
+  atom: MakeAtom;
+  computed: MakeComputed;
+  update: MakeUpdate;
+  fromContext: MakeContextHook<ContextShape>;
+};
+
 export type DefineState = <
   InnerStateShape extends Record<string, Signal<unknown> | ExposedUpdater>,
   OuterStateShape extends {
@@ -47,10 +54,5 @@ export type DefineState = <
   Args extends unknown[],
   ContextShape,
 >(
-  defineStateCb: (
-    atom: MakeAtom,
-    computed: MakeComputed,
-    update: MakeUpdate,
-    fromContext: MakeContextHook<ContextShape>,
-  ) => (...args: Args) => InnerStateShape,
+  defineStateCb: (api: ExposedAPIs<ContextShape>) => (...args: Args) => InnerStateShape,
 ) => (...args: Args) => Signal<OuterStateShape>;


### PR DESCRIPTION
# Description

This PR aims to improve the DX when defining a state manager.

Before this PR the `defineState` callback receives a set of APIs as arguments, example: `defineState((_atom, _computed, _update, fromContext) =>...`. The main inconvenients are:
1. you need to declare all of them until you find the one you want (`fromContext`)
2. As the framework evolves, we may add more apis, and the list could go on.

This PR targets those, by making the `defineState` callback to receive a set of APIs in the form of an object, in that way the users could desctuct only those that will be used in the state manager: `defineState(({ fromContext }) =>...`

🔴 This PR is a breaking change.

Note: the CI is failing with an error (seems to be unrelated to the changes as they pass in my local).

```
 ❌ Failed to launch the browser process!
[2117:2117:0327/194345.164448:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0327/194345.173119:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0327/194345.173159:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```