### PR TITLE
chore: rollback to ubuntu-22.04 due to issues with puppeteer in 24.04

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       HUSKY: 0


### PR DESCRIPTION
This PR reverts to ubuntu 22.04 due [this issue with puppeteer.](https://github.com/puppeteer/puppeteer/issues/12818) The image was updated in 01/17/2024 according to [this post](https://github.com/actions/runner-images/issues/10636).