### PR TITLE
refactor: changes computer signature

### DIFF
--- a/packages/@lwc/state/README.md
+++ b/packages/@lwc/state/README.md
@@ -51,7 +51,7 @@ const useCounter = defineState(
       // Create reactive atom
       const count = atom(initialValue);
       // Create computed value
-      const doubleCount = computed({ count }, ({ count }) => count * 2);
+      const doubleCount = computed([count], (countValue) => countValue * 2);
       // Create update function
       const increment = update({ count }, ({ count }) => ({
         count: count + 1,

--- a/packages/@lwc/state/src/__tests__/index.test.ts
+++ b/packages/@lwc/state/src/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { defineState } from '../index.js';
+
 // biome-ignore lint: test only
 let doubleCountNotifySpy: any;
 // biome-ignore lint: test only
@@ -14,13 +15,13 @@ const state = defineState((atom, computed, update, _fromContext) => (...args) =>
   const count = atom(countArg);
   const fruit = atom(fruitArg);
 
-  const doubleCount = computed({ count }, ({ count: countValue }) => (countValue as number) * 2);
+  const doubleCount = computed([count], (countValue) => (countValue as number) * 2);
   // @ts-ignore
   doubleCountNotifySpy = vi.spyOn(doubleCount, 'notify');
 
   const fruitNameAndCount = computed(
-    { fruit, count },
-    ({ fruit, count }) => `I have ${count} ${fruit}${(count as number) > 1 ? 's' : ''}`,
+    [fruit, count],
+    (fruit, count) => `I have ${count} ${fruit}${(count as number) > 1 ? 's' : ''}`,
   );
   // @ts-ignore
   fruitNameAndCountNotifySpy = vi.spyOn(fruitNameAndCount, 'notify');

--- a/packages/@lwc/state/src/index.ts
+++ b/packages/@lwc/state/src/index.ts
@@ -46,32 +46,32 @@ class ContextAtomSignal<T> extends AtomSignal<T> {
 
 class ComputedSignal<T> extends SignalBaseClass<T> {
   private computer: Computer<unknown>;
-  private dependencies: Record<string, Signal<unknown>>;
+  private dependencies: Signal<unknown>[];
   private _value: T;
   private isStale = true;
 
-  constructor(inputSignalsObj: Record<string, Signal<unknown>>, computer: Computer<unknown>) {
+  constructor(inputSignals: Signal<unknown>[], computer: Computer<unknown>) {
     super();
     this.computer = computer;
-    this.dependencies = inputSignalsObj;
+    this.dependencies = inputSignals;
 
     const onUpdate = () => {
       this.isStale = true;
       this.notify();
     };
 
-    for (const signal of Object.values(inputSignalsObj)) {
+    for (const signal of inputSignals) {
       signal.subscribe(onUpdate);
     }
   }
 
   private computeValue() {
-    const dependencyValues: Record<string, unknown> = {};
-    for (const [signalName, signal] of Object.entries(this.dependencies)) {
-      dependencyValues[signalName] = signal.value;
+    const dependencyValues: unknown[] = [];
+    for (const [index, signal] of this.dependencies.entries()) {
+      dependencyValues[index] = signal.value;
     }
     this.isStale = false;
-    this._value = this.computer(dependencyValues) as T;
+    this._value = this.computer(...dependencyValues) as T;
   }
 
   protected override notify(): void {

--- a/packages/@lwc/state/src/types.ts
+++ b/packages/@lwc/state/src/types.ts
@@ -5,15 +5,9 @@ export type UnwrapSignal<T> = T extends Signal<infer Inner> ? Inner : T;
 
 export type MakeAtom = <T>(val: T) => Signal<T>;
 
-export type Computer<T> = (signalValues: Record<string, unknown>) => T;
+export type Computer<T> = (...signalValues: unknown[]) => T;
 
-export type MakeComputed = <
-  InputSignals extends Record<string, Signal<unknown>>,
-  SignalValues extends {
-    [SignalName in keyof InputSignals]: UnwrapSignal<InputSignals[SignalName]>;
-  },
-  ComputedType,
->(
+export type MakeComputed = <InputSignals extends Signal<unknown>[], ComputedType>(
   inputSignals: InputSignals,
   computer: Computer<ComputedType>,
 ) => Signal<ComputedType>;


### PR DESCRIPTION
# Description

With https://github.com/salesforce/lightning-labs/pull/57 removing the update, we can refactor the computed.

Before this PR:

```ts
const doubleCount = computed({ count }, ({ count }) => count * 2);
```

After this PR:

```ts
const doubleCount = computed([count], (countValue) => countValue * 2);
// or
const doubleCount = computed([count], () => count.value * 2);
```